### PR TITLE
Fix 32bit architecture string

### DIFF
--- a/public/install
+++ b/public/install
@@ -49,7 +49,7 @@ archive_os() {
 archive_arch() {
   case "$(uname -m)" in
   x86_64) echo "amd64" ;;
-  *)      echo "i386" ;;
+  *)      echo "386" ;;
   esac
 }
 


### PR DESCRIPTION
The release archives use `386` instead of `i386`
