### PR TITLE
Fixed issue with homebrew instructions.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,7 +70,7 @@
             <p>If you have homebrew installed, then you can install the CLI with the following command:</p>
 
 <pre class="content-code">
-  $ brew tap homebrew-binary
+  $ brew tap homebrew/binary
   $ brew install exercism
 </pre>
           </div>


### PR DESCRIPTION
brew tap pulls down repos from github in the 'user/repo' format, not 'user-repo'
