### PR TITLE
Check the return value of the tarball extraction

### DIFF
--- a/public/install
+++ b/public/install
@@ -140,8 +140,8 @@ check_directory_in_path() {
 install() {
   EXERCISM_FILES="https://github.com/exercism/cli/releases/download/$VERSION/exercism-$OS-$ARCH.tgz"
   echo "\nDownloading $EXERCISM_FILES...\n"
-  download $EXERCISM_FILES| extract "$DIR"
-  echo "Installed exercism to $DIR"
+  download $EXERCISM_FILES | extract "$DIR"
+  [ $? -eq 0 ] && echo "Installed exercism to $DIR"
 }
 
 download() {


### PR DESCRIPTION
Prevents a wrong success message from appearing if the download or
extraction fails.

Addresses exercism/exercism.io#2029
