### PR TITLE
Expand newlines in the installation script

### DIFF
--- a/public/install
+++ b/public/install
@@ -140,7 +140,7 @@ check_directory_in_path() {
 
 install() {
   EXERCISM_FILES="https://github.com/exercism/cli/releases/download/$VERSION/exercism-$OS-$ARCH.tgz"
-  echo "\nDownloading $EXERCISM_FILES...\n"
+  echo -e "\nDownloading $EXERCISM_FILES...\n"
   download $EXERCISM_FILES | extract "$DIR"
   [ $? -eq 0 ] && echo "Installed exercism to $DIR"
 }


### PR DESCRIPTION
Enable backslash escaping in the installation script to expand newlines.
Otherwise, people see the following when they install:

    \nDownloading https://github.com/exercism/cli/releases/download/v2.2.1/exercism-linux-64bit.tgz...\n